### PR TITLE
ENH: Transition CI to GHA

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -1,0 +1,87 @@
+name: test, package
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # max-parallel: 6
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: ['2.7', '3.5', '3.6', '3.7']
+        requires: ['minimal', 'latest']
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set min. dependencies
+      if: matrix.requires == 'minimal'
+      run: |
+        python -c "req = open('requirements.txt').read().replace('>=', '==') ; open('requirements.txt', 'w').write(req)"
+
+    # - name: Cache pip
+    #   uses: actions/cache@v2
+    #   id: cache
+    #   with:
+    #     path: ${{ env.pythonLocation }}
+    #     # Look to see if there is a cache hit for the corresponding requirements files
+    #     key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/*') }}
+    #     restore-keys: |
+    #       ${{ env.pythonLocation }}-
+
+    - name: Install dependencies
+      # if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        python -m pip install --upgrade --user pip
+        pip install -r requirements.txt
+        python --version
+        pip --version
+        pip list
+
+    - name: Run tests
+      run: |
+        # tox --sitepackages
+        python -c 'import tract_querier'
+        coverage run --source tract_querier -m pytest tract_querier -o junit_family=xunit2 -v --doctest-modules --durations=10 --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
+
+    - name: Upload pytest test results
+      uses: actions/upload-artifact@master
+      with:
+        name: pytest-results-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.requires }}
+        path: junit/test-results-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.requires }}.xml
+      # Use always() to always run this step to publish test results when there are test failures
+      if: always()
+
+    - name: Statistics
+      if: success()
+      run: |
+         coverage report
+
+    - name: Package Setup
+    # - name: Run tests with tox
+      run: |
+        pip install build
+        # check-manifest
+        python -m build
+        # twine check dist/
+        # tox --sitepackages
+        # python -m tox


### PR DESCRIPTION
Transition CI from TravisCI to GitHub Actions: add the corresponding GHA workflow file to test and package the tool.

Remove the TravisCI config file.